### PR TITLE
.gitignore 추가, orchestrator.py에 엔드포인트 탐지에 권한 헤더를 포함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+**/__pycache__/
+
+data/
+*.db
+
+graveyard/

--- a/src/orchestrator/orchestrator.py
+++ b/src/orchestrator/orchestrator.py
@@ -1,14 +1,16 @@
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import Header, FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel, Field
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 import secrets
 import logging
+import os
+
 
 # 로그 설정
 logging.basicConfig(level=logging.INFO, format='%(asctime)s | %(levelname)s | ORCHESTRATOR | %(message)s')
 logger = logging.getLogger(__name__)
-
+BOSS_TOKEN = os.getenv("BOSS_TOKEN", "")
 app = FastAPI(title="Orchestrator API", version="0.1")
 
 TASK_STORE: Dict[str, Dict[str, Any]] = {}
@@ -57,7 +59,7 @@ def _enqueue_task(task_id: str, payload: Dict[str, Any]):
 
 
 @app.post('/detect', response_model=DetectResponse)
-async def detect_endpoint(req: DetectRequest, background_tasks: BackgroundTasks):
+async def detect_endpoint(req: DetectRequest, background_tasks: BackgroundTasks, authorization: Optional[str] = Header(None),):
     if BOSS_TOKEN:
         if not authorization or not authorization.startswith("Bearer "):
             raise HTTPException(status_code=401, detail="Missing Authorization header")


### PR DESCRIPTION
.gitignore 파일을 추가하고 orchestrator.py 을 업데이트하여 엔드포인트 탐지에 권한 헤더를 포함하도록 합니다

## Summary by Sourcery

Add authorization header handling to the detection endpoint and introduce a project .gitignore file.

New Features:
- Require and validate an optional Bearer authorization header for the /detect API endpoint when a BOSS token is configured.

Enhancements:
- Load a BOSS access token from environment variables for securing the detection endpoint.

Build:
- Add a .gitignore file to exclude appropriate files from version control.